### PR TITLE
.438081291297676:d6388457cd22394c5077015d245ac74c_69ef6cdfdf20d71b25c740ab.69ef6cf8df20d71b25c740bf.69ef6cf8947dd91877190258:Trae CN.T(2026/4/27 22:04:50)

### DIFF
--- a/sshclick/cli/commands/config/config_del.py
+++ b/sshclick/cli/commands/config/config_del.py
@@ -26,4 +26,5 @@ def cmd(ctx, host_style):
         print(str(exc))
         return
 
-    config.generate_ssh_config()
+    if config.generate_ssh_config():
+        print("Deleted config: host-style")

--- a/sshclick/cli/commands/config/config_set.py
+++ b/sshclick/cli/commands/config/config_set.py
@@ -29,6 +29,7 @@ def cmd(ctx, host_style):
         print(str(exc))
         return
 
-    config.generate_ssh_config()
+    if config.generate_ssh_config():
+        print(f"Set config: host-style={host_style}")
 
         

--- a/sshclick/cli/commands/host/host_delete.py
+++ b/sshclick/cli/commands/host/host_delete.py
@@ -37,8 +37,8 @@ def cmd(ctx, names, yes):
     selected_hosts_list = expand_names(names, config.get_all_host_names())
     selected_hosts_list.sort()
     
-    # Deleting requires confirmation
-    if not yes:
+    # Deleting requires confirmation if not in dry-run mode
+    if not yes and not config.diff:
         print(f"Following hosts will be deleted: [{','.join(selected_hosts_list)}]")
         if not click.confirm('Are you sure?'):
             ctx.exit(1)

--- a/sshclick/cli/commands/host/host_set.py
+++ b/sshclick/cli/commands/host/host_set.py
@@ -60,8 +60,8 @@ def cmd(ctx, names, info, parameter, target_group_name, force, yes):
     selected_hosts_list = expand_names(names, config.get_all_host_names())
     selected_hosts_list.sort()
 
-    # For setting stuff, we confirm only if it applies on more hosts
-    if not yes:
+    # For setting stuff, we confirm only if it applies on more hosts and not in dry-run mode
+    if not yes and not config.diff:
         if len(selected_hosts_list) > 1:
             print(f"Following hosts will be changed: [{','.join(selected_hosts_list)}]")
             if not click.confirm('Are you sure?'):

--- a/sshclick/main_cli.py
+++ b/sshclick/main_cli.py
@@ -16,7 +16,8 @@ using this software, as you might accidentally lose some configuration.
 
 # Parameters help:
 STDOUT_HELP = "Send changed SSH config to STDOUT instead to original file. Can be enabled with setting ENV variable (export SSHC_STDOUT=1)"
-DIFF_HELP = "Show only difference is config changes, instead of applying them. Can be enabled with setting ENV variable (export SSHC_DIFF=1)"
+DRYRUN_HELP = "Show only diff of config changes, instead of applying them. Can be enabled with setting ENV variable (export SSHC_DRYRUN=1)"
+DIFF_HELP = "Alias for --dry-run. Show only diff of config changes, instead of applying them. Can be enabled with setting ENV variable (export SSHC_DIFF=1)"
 # ------------------------------------------------------------------------------
 
 
@@ -25,11 +26,12 @@ DIFF_HELP = "Show only difference is config changes, instead of applying them. C
 @click.group(context_settings=CONTEXT_SETTINGS, help=MAIN_HELP)
 @click.option("--config", default=USER_SSH_CONFIG, envvar=SSHCONFIG_ENVVAR, help=SSHCONFIG_HELP)
 @click.option("--stdout", is_flag=True, envvar="SSHC_STDOUT", help=STDOUT_HELP)
+@click.option("--dry-run", "--dryrun", "dry_run", is_flag=True, envvar="SSHC_DRYRUN", help=DRYRUN_HELP)
 @click.option("--diff", is_flag=True, envvar="SSHC_DIFF", help=DIFF_HELP)
 @click.version_option(VERSION, message="SSHClick (sshc) - Version: %(version)s")
 @click.pass_context
-def cli(ctx: click.core.Context, config: str, stdout: bool, diff: bool):
-    ctx.obj = load_ssh_config(config, stdout=stdout, diff=diff)
+def cli(ctx: click.core.Context, config: str, stdout: bool, dry_run: bool, diff: bool):
+    ctx.obj = load_ssh_config(config, stdout=stdout, diff=dry_run or diff)
 
 
 # Link all commands to root command

--- a/tests/test_7_dryrun_mode.py
+++ b/tests/test_7_dryrun_mode.py
@@ -1,0 +1,370 @@
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from sshclick import main_cli
+from sshclick.core import SSH_Config
+
+
+TEST_CONFIG = Path(__file__).resolve().parent / "config_example"
+
+
+class TestDryRunHostOperations:
+    """Test dry-run mode for host-related write operations."""
+
+    def test_dryrun_host_create_does_not_modify_config(self, tmp_path):
+        """--dry-run with host create should show diff but not modify config."""
+        config_path = tmp_path / "config"
+        config_content = "Host existing-host\n    hostname 10.0.0.1\n"
+        config_path.write_text(config_content, encoding="utf-8")
+        original_content = config_path.read_text(encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main_cli.cli,
+            [
+                "--config", str(config_path),
+                "--dry-run",
+                "host", "create",
+                "-a", "192.168.1.1",
+                "-u", "testuser",
+                "new-host"
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert config_path.read_text(encoding="utf-8") == original_content
+        assert "+Host new-host" in result.output
+        assert "Created host:" not in result.output
+
+    def test_diff_option_alias_works_same_as_dryrun(self, tmp_path):
+        """--diff should work as alias for --dry-run."""
+        config_path = tmp_path / "config"
+        config_content = "Host existing-host\n    hostname 10.0.0.1\n"
+        config_path.write_text(config_content, encoding="utf-8")
+        original_content = config_path.read_text(encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main_cli.cli,
+            [
+                "--config", str(config_path),
+                "--diff",
+                "host", "create",
+                "-a", "192.168.1.1",
+                "new-host"
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert config_path.read_text(encoding="utf-8") == original_content
+        assert "+Host new-host" in result.output
+
+    def test_dryrun_host_delete_does_not_modify_config(self, tmp_path):
+        """--dry-run with host delete should show diff but not modify config."""
+        config_path = tmp_path / "config"
+        config_content = "Host host-to-delete\n    hostname 10.0.0.1\n"
+        config_path.write_text(config_content, encoding="utf-8")
+        original_content = config_path.read_text(encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main_cli.cli,
+            [
+                "--config", str(config_path),
+                "--dry-run",
+                "host", "delete",
+                "host-to-delete"
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert config_path.read_text(encoding="utf-8") == original_content
+        assert "-Host host-to-delete" in result.output
+        assert "Deleted hosts:" not in result.output
+
+    def test_dryrun_host_rename_does_not_modify_config(self, tmp_path):
+        """--dry-run with host rename should show diff but not modify config."""
+        config_path = tmp_path / "config"
+        config_content = "Host old-name\n    hostname 10.0.0.1\n"
+        config_path.write_text(config_content, encoding="utf-8")
+        original_content = config_path.read_text(encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main_cli.cli,
+            [
+                "--config", str(config_path),
+                "--dry-run",
+                "host", "rename",
+                "old-name", "new-name"
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert config_path.read_text(encoding="utf-8") == original_content
+        assert "-Host old-name" in result.output
+        assert "+Host new-name" in result.output
+        assert "Renamed host:" not in result.output
+
+    def test_dryrun_host_set_does_not_modify_config(self, tmp_path):
+        """--dry-run with host set should show diff but not modify config."""
+        config_path = tmp_path / "config"
+        config_content = "Host test-host\n    hostname 10.0.0.1\n    user olduser\n"
+        config_path.write_text(config_content, encoding="utf-8")
+        original_content = config_path.read_text(encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main_cli.cli,
+            [
+                "--config", str(config_path),
+                "--dry-run",
+                "host", "set",
+                "-p", "user", "newuser",
+                "test-host"
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert config_path.read_text(encoding="utf-8") == original_content
+        assert "-    user olduser" in result.output
+        assert "+    user newuser" in result.output
+        assert "Modified host:" not in result.output
+
+    def test_dryrun_host_delete_skips_confirmation(self, tmp_path):
+        """--dry-run should skip confirmation dialog for host delete."""
+        config_path = tmp_path / "config"
+        config_content = "Host host1\n    hostname 10.0.0.1\n"
+        config_path.write_text(config_content, encoding="utf-8")
+        original_content = config_path.read_text(encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main_cli.cli,
+            [
+                "--config", str(config_path),
+                "--dry-run",
+                "host", "delete",
+                "host1"
+            ],
+            input="n\n"
+        )
+
+        assert result.exit_code == 0
+        assert config_path.read_text(encoding="utf-8") == original_content
+        assert "Are you sure?" not in result.output
+
+
+class TestDryRunGroupOperations:
+    """Test dry-run mode for group-related write operations."""
+
+    def test_dryrun_group_create_does_not_modify_config(self, tmp_path):
+        """--dry-run with group create should show diff but not modify config."""
+        config_path = tmp_path / "config"
+        config_content = "Host existing-host\n    hostname 10.0.0.1\n"
+        config_path.write_text(config_content, encoding="utf-8")
+        original_content = config_path.read_text(encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main_cli.cli,
+            [
+                "--config", str(config_path),
+                "--dry-run",
+                "group", "create",
+                "-d", "Test description",
+                "new-group"
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert config_path.read_text(encoding="utf-8") == original_content
+        assert "+#@group: new-group" in result.output
+        assert "Created group:" not in result.output
+
+    def test_dryrun_group_delete_does_not_modify_config(self, tmp_path):
+        """--dry-run with group delete should show diff but not modify config."""
+        config_path = tmp_path / "config"
+        config_content = (
+            "#@group: group-to-delete\n"
+            "#@desc: Test group\n"
+            "Host test-host\n    hostname 10.0.0.1\n"
+        )
+        config_path.write_text(config_content, encoding="utf-8")
+        original_content = config_path.read_text(encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main_cli.cli,
+            [
+                "--config", str(config_path),
+                "--dry-run",
+                "group", "delete",
+                "group-to-delete"
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert config_path.read_text(encoding="utf-8") == original_content
+        assert "-#@group: group-to-delete" in result.output
+        assert "Deleted group:" not in result.output
+
+    def test_dryrun_group_rename_does_not_modify_config(self, tmp_path):
+        """--dry-run with group rename should show diff but not modify config."""
+        config_path = tmp_path / "config"
+        config_content = (
+            "#@group: old-group\n"
+            "Host test-host\n    hostname 10.0.0.1\n"
+        )
+        config_path.write_text(config_content, encoding="utf-8")
+        original_content = config_path.read_text(encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main_cli.cli,
+            [
+                "--config", str(config_path),
+                "--dry-run",
+                "group", "rename",
+                "old-group", "new-group"
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert config_path.read_text(encoding="utf-8") == original_content
+        assert "-#@group: old-group" in result.output
+        assert "+#@group: new-group" in result.output
+        assert "Renamed group:" not in result.output
+
+    def test_dryrun_group_set_does_not_modify_config(self, tmp_path):
+        """--dry-run with group set should show diff but not modify config."""
+        config_path = tmp_path / "config"
+        config_content = (
+            "#@group: test-group\n"
+            "#@desc: Old description\n"
+            "Host test-host\n    hostname 10.0.0.1\n"
+        )
+        config_path.write_text(config_content, encoding="utf-8")
+        original_content = config_path.read_text(encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main_cli.cli,
+            [
+                "--config", str(config_path),
+                "--dry-run",
+                "group", "set",
+                "-d", "New description",
+                "test-group"
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert config_path.read_text(encoding="utf-8") == original_content
+        assert "-#@desc: Old description" in result.output
+        assert "+#@desc: New description" in result.output
+        assert "Modified group:" not in result.output
+
+
+class TestDryRunConfigOperations:
+    """Test dry-run mode for config-related write operations."""
+
+    def test_dryrun_config_set_does_not_modify_config(self, tmp_path):
+        """--dry-run with config set should show diff but not modify config."""
+        config_path = tmp_path / "config"
+        config_content = ""
+        config_path.write_text(config_content, encoding="utf-8")
+        original_content = config_path.read_text(encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main_cli.cli,
+            [
+                "--config", str(config_path),
+                "--dry-run",
+                "config", "set",
+                "--host-style", "simple"
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert config_path.read_text(encoding="utf-8") == original_content
+        assert "+#@config: host-style=simple" in result.output
+        assert "Set config:" not in result.output
+
+    def test_dryrun_config_del_does_not_modify_config(self, tmp_path):
+        """--dry-run with config del should show diff but not modify config."""
+        config_path = tmp_path / "config"
+        config_content = (
+            "#<<<<< SSH Config file managed by sshclick >>>>>\n"
+            "#@config: host-style=simple\n"
+        )
+        config_path.write_text(config_content, encoding="utf-8")
+        original_content = config_path.read_text(encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main_cli.cli,
+            [
+                "--config", str(config_path),
+                "--dry-run",
+                "config", "del",
+                "--host-style"
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert config_path.read_text(encoding="utf-8") == original_content
+        assert "-#@config: host-style=simple" in result.output
+        assert "Deleted config:" not in result.output
+
+
+class TestDryRunEnvironmentVariables:
+    """Test dry-run mode via environment variables."""
+
+    def test_sshc_dryrun_envvar_enables_dryrun(self, tmp_path):
+        """SSHC_DRYRUN environment variable should enable dry-run mode."""
+        config_path = tmp_path / "config"
+        config_content = "Host existing-host\n    hostname 10.0.0.1\n"
+        config_path.write_text(config_content, encoding="utf-8")
+        original_content = config_path.read_text(encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main_cli.cli,
+            [
+                "--config", str(config_path),
+                "host", "create",
+                "-a", "192.168.1.1",
+                "new-host"
+            ],
+            env={"SSHC_DRYRUN": "1"}
+        )
+
+        assert result.exit_code == 0
+        assert config_path.read_text(encoding="utf-8") == original_content
+        assert "+Host new-host" in result.output
+
+    def test_sshc_diff_envvar_enables_dryrun(self, tmp_path):
+        """SSHC_DIFF environment variable should enable dry-run mode (backward compatible)."""
+        config_path = tmp_path / "config"
+        config_content = "Host existing-host\n    hostname 10.0.0.1\n"
+        config_path.write_text(config_content, encoding="utf-8")
+        original_content = config_path.read_text(encoding="utf-8")
+
+        result = CliRunner().invoke(
+            main_cli.cli,
+            [
+                "--config", str(config_path),
+                "host", "create",
+                "-a", "192.168.1.1",
+                "new-host"
+            ],
+            env={"SSHC_DIFF": "1"}
+        )
+
+        assert result.exit_code == 0
+        assert config_path.read_text(encoding="utf-8") == original_content
+        assert "+Host new-host" in result.output
+
+
+class TestDryRunHelpText:
+    """Test that help text mentions dry-run options."""
+
+    def test_help_mentions_dry_run(self):
+        """Main help should mention --dry-run option."""
+        result = CliRunner().invoke(main_cli.cli, ["--help"])
+
+        assert result.exit_code == 0
+        assert "--dry-run" in result.output
+        assert "--dryrun" in result.output
+        assert "--diff" in result.output


### PR DESCRIPTION
添加--dry-run选项用于显示变更差异而不实际修改配置文件
将--diff作为--dry-run的别名保持向后兼容
在dry-run模式下跳过确认对话框
添加相关测试用例验证dry-run功能